### PR TITLE
RA-1283 Environmental Allergens are not working correctly

### DIFF
--- a/api/src/main/java/org/openmrs/module/allergyapi/AllergenType.java
+++ b/api/src/main/java/org/openmrs/module/allergyapi/AllergenType.java
@@ -14,5 +14,5 @@
 package org.openmrs.module.allergyapi;
 
 public enum AllergenType {
-	DRUG, FOOD, ENVIRONMENT
+	DRUG, FOOD, ENVIRONMENT, OTHER
 }


### PR DESCRIPTION
Now ,all of the allergens apart from food and drugs are shown under the "other" tab. This is as per the talk discussion here : https://talk.openmrs.org/t/two-bugs-about-allergies-and-appointments/9689/8 .The changes made are such that they support both Platform 1.9 and 2.x thus preserving backward compatibility.

https://issues.openmrs.org/browse/RA-1283